### PR TITLE
Apply upcoming races spans to the base html/css

### DIFF
--- a/graphics/Upcoming_Races.html
+++ b/graphics/Upcoming_Races.html
@@ -20,29 +20,29 @@
 
       <!-- Upcoming Runs -->
       <div class="on-deck-info-container" id="on-deck-info-container1">
-         <div class="info" id="on-deck-info1"></div>
+         <div class="info" id="on-deck-info1"><span></span></div>
       </div>
       <div class="tech-info-container" id="tech-info-container1">
-         <div class="on-deck-channel" id="on-deck-channel1"></div>
-         <div class="on-deck-start" id="on-deck-start1"></div>
+         <div class="on-deck-channel" id="on-deck-channel1"><span></span></div>
+         <div class="on-deck-start" id="on-deck-start1"><span></span></div>
       </div>
       
       <!-- <div class="on-deck-game" id="on-deck-game2"></div> -->
       <div class="on-deck-info-container" id="on-deck-info-container2">
-         <div class="info" id="on-deck-info2"></div>
+         <div class="info" id="on-deck-info2"><span></span></div>
       </div>
       <div class="tech-info-container" id="tech-info-container2">
-         <div class="on-deck-channel" id="on-deck-channel2"></div>
-         <div class="on-deck-start" id="on-deck-start2"></div>
+         <div class="on-deck-channel" id="on-deck-channel2"><span></span></div>
+         <div class="on-deck-start" id="on-deck-start2"><span></span></div>
       </div>
 
       <!-- <div class="on-deck-game" id="on-deck-game2"></div> -->
       <div class="on-deck-info-container" id="on-deck-info-container3">
-         <div class="info" id="on-deck-info3"></div>
+         <div class="info" id="on-deck-info3"><span></span></div>
       </div>
       <div class="tech-info-container" id="tech-info-container3">
-         <div class="on-deck-channel" id="on-deck-channel3"></div>
-         <div class="on-deck-start" id="on-deck-start3"></div>
+         <div class="on-deck-channel" id="on-deck-channel3"><span></span></div>
+         <div class="on-deck-start" id="on-deck-start3"><span></span></div>
       </div>
 
       <div class="comms-container" id="comms-container1">

--- a/graphics/css/upcoming_races.css
+++ b/graphics/css/upcoming_races.css
@@ -40,6 +40,10 @@
 	flex: 1;
 }
 
+.info span {
+	white-space:nowrap;
+}
+
 .tech-info-container {
 	position: absolute;
 	display: inline-block;
@@ -96,11 +100,19 @@
 	margin-right: 151px;
 }
 
+.on-deck-channel span {
+	white-space:nowrap;
+}
+
 .on-deck-start {
 	display: inline-block;
 	font-stretch: normal;
 	width: 439px;
 	padding-right: 5px;
+}
+
+.on-deck-start span {
+	white-space:nowrap;
 }
 
 /* Commentator name and pronouns panel. */


### PR DESCRIPTION
JQuery's `width()` method can return inaccurate results when loading the upcoming races layout. My guess is that this is due to the way we set up the `<span>`. We do it in javascript just before calling `width()`. I suppose it's possible the update is not done in time for the width to return the updated result. This in turn leads to a smaller adjustement to the font size than necessary, meaning the overall text ends up not fitting the div.

This PR adds the span to the base HTML and CSS. With this approach, `width()` should return the correct result. The upcoming races issue should therefore be fixed.